### PR TITLE
Update the e2e config to use the SSL version of the site but allow for certificate errors in Chrome.

### DIFF
--- a/config/protractor/protractor.conf.js
+++ b/config/protractor/protractor.conf.js
@@ -17,12 +17,12 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome',
     'chromeOptions': {
-      'args': ['--disable-extensions']
+      'args': ['--disable-extensions --ignore-certificate-errors']
     }
   },
   directConnect: true,
   // seleniumAddress: 'http://localhost:4444/wd/hub',
-  baseUrl: 'http://sky.blackbaud-dev.com',
+  baseUrl: 'https://sky.blackbaud-dev.com',
   framework: 'jasmine',
   jasmineNodeOpts: {
     showColors: true,


### PR DESCRIPTION
Update the e2e config to use the SSL version of the site but allow for certificate errors in Chrome